### PR TITLE
Migrate dev-dependencies to dependency-groups

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -5,15 +5,15 @@ on:
     branches:
       - main
     paths:
-      - Pipfile
-      - Pipfile.lock
+      - pyproject.toml
+      - uv.lock
       - .devcontainer/Dockerfile
   pull_request:
     branches:
       - main
     paths:
-      - Pipfile
-      - Pipfile.lock
+      - pyproject.toml
+      - uv.lock
       - .devcontainer/Dockerfile
   workflow_dispatch:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dynamic = ["version"]
 [project.scripts]
 python_training_project = "python_training_project.__main__:cli"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "coverage",
     "flake8",
     "mypy",


### PR DESCRIPTION
As specified in [PEP 735](https://peps.python.org/pep-0735/) development dependencies can now be specified within `pyproject.toml` using `[dependency-groups]`.