### PR TITLE
Prefix binary commands with uv run

### DIFF
--- a/tools/build-docs.sh
+++ b/tools/build-docs.sh
@@ -8,6 +8,6 @@ pushd "${REPO_ROOT}" 2>&1 > /dev/null
 echo "Building documentation..."
 mkdir -p build
 cd docs
-make html
+uv run --all-groups make html
 
 popd 2>&1 > /dev/null

--- a/tools/lint-package.sh
+++ b/tools/lint-package.sh
@@ -11,31 +11,31 @@ STATUS=0
 set +e
 
 echo "Running flake8..."
-flake8 src/python_training_project --format=pylint > build/flake8.txt
+uv run --all-groups flake8 src/python_training_project --format=pylint > build/flake8.txt
 if [ $? -ne 0 ]; then
     STATUS=1
 fi
 
 echo "Running mypy..."
-mypy src/python_training_project > build/mypy.txt
+uv run --all-groups mypy src/python_training_project > build/mypy.txt
 if [ $? -ne 0 ]; then
     STATUS=1
 fi
 
 echo "Running pylint..."
-pylint src/python_training_project --msg-template="{path}:{line}: [{msg_id}, {obj}] {msg} ({symbol})" > build/pylint.txt
+uv run --all-groups pylint src/python_training_project --msg-template="{path}:{line}: [{msg_id}, {obj}] {msg} ({symbol})" > build/pylint.txt
 if [ $? -ne 0 ]; then
     STATUS=1
 fi
 
 echo "Running ruff check..."
-ruff check > build/ruff.txt
+uv run --all-groups ruff check > build/ruff.txt
 if [ $? -ne 0 ]; then
     STATUS=1
 fi
 
 echo "Running ruff format..."
-ruff format --check
+uv run --all-groups ruff format --check
 if [ $? -ne 0 ]; then
     STATUS=1
 fi

--- a/tools/test-package.sh
+++ b/tools/test-package.sh
@@ -8,6 +8,6 @@ pushd "${REPO_ROOT}" 2>&1 > /dev/null
 mkdir -p build
 
 echo "Running tests..."
-pytest
+uv run --all-groups pytest
 
 popd 2>&1 > /dev/null


### PR DESCRIPTION
Always executing commands with `uv run` allows easier usage of the example project within different CI environments, e.g. using a Python container, native Python installation, etc.