### PR TITLE
Move uv cache to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 __pycache__
 .coverage
-.mypy_cache
-.pytest_cache
+.*_cache
 .venv
 *.egg-info
 _build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ dev = [
     "sphinx-rtd-theme",
 ]
 
+[tool.uv]
+cache-dir = "./.uv_cache"
+cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true } }]
+
 [tool.setuptools_scm]
 write_to = "src/python_training_project/version.py"
 

--- a/tools/build-docs.sh
+++ b/tools/build-docs.sh
@@ -3,6 +3,10 @@
 # Get Git root directory
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
+# Force the uv cache directory to be located in the repository root
+# to avoid permission issues within CI/CD environments.
+export UV_CACHE_DIR="${REPO_ROOT}/.uv_cache"
+
 pushd "${REPO_ROOT}" 2>&1 > /dev/null
 
 echo "Building documentation..."

--- a/tools/build-package.sh
+++ b/tools/build-package.sh
@@ -3,6 +3,10 @@
 # Get Git root directory
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
+# Force the uv cache directory to be located in the repository root
+# to avoid permission issues within CI/CD environments.
+export UV_CACHE_DIR="${REPO_ROOT}/.uv_cache"
+
 pushd "${REPO_ROOT}" 2>&1 > /dev/null
 
 echo "Building package..."

--- a/tools/deploy-package.sh
+++ b/tools/deploy-package.sh
@@ -3,6 +3,10 @@
 # Get Git root directory
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
+# Force the uv cache directory to be located in the repository root
+# to avoid permission issues within CI/CD environments.
+export UV_CACHE_DIR="${REPO_ROOT}/.uv_cache"
+
 pushd "${REPO_ROOT}" 2>&1 > /dev/null
 
 echo "Deploying package..."

--- a/tools/lint-package.sh
+++ b/tools/lint-package.sh
@@ -3,6 +3,10 @@
 # Get Git root directory
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
+# Force the uv cache directory to be located in the repository root
+# to avoid permission issues within CI/CD environments.
+export UV_CACHE_DIR="${REPO_ROOT}/.uv_cache"
+
 pushd "${REPO_ROOT}" 2>&1 > /dev/null
 
 mkdir -p build

--- a/tools/test-package.sh
+++ b/tools/test-package.sh
@@ -3,6 +3,10 @@
 # Get Git root directory
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
+# Force the uv cache directory to be located in the repository root
+# to avoid permission issues within CI/CD environments.
+export UV_CACHE_DIR="${REPO_ROOT}/.uv_cache"
+
 pushd "${REPO_ROOT}" 2>&1 > /dev/null
 
 mkdir -p build


### PR DESCRIPTION
In CI/CD environments running in Docker containers without privileges, the default uv cache location might lead to 'access denied' errors. Therefore, we move the uv cache directory to the repository root (similar to pytest, mypy, ruff, etc).

See: https://docs.astral.sh/uv/concepts/cache/