### PR TITLE
Move pylint cache to repo root

### DIFF
--- a/tools/lint-package.sh
+++ b/tools/lint-package.sh
@@ -6,6 +6,9 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 # Force the uv cache directory to be located in the repository root
 # to avoid permission issues within CI/CD environments.
 export UV_CACHE_DIR="${REPO_ROOT}/.uv_cache"
+# Force the pylint cache directory to be located in the repository root
+# to avoid permission issues within CI/CD environments.
+export PYLINTHOME="${REPO_ROOT}/.pylint_cache"
 
 pushd "${REPO_ROOT}" 2>&1 > /dev/null
 


### PR DESCRIPTION
In CI/CD environments running in Docker containers without privileges, the default pylint cache location might lead to 'access denied' errors. Therefore, we move the pylint cache directory to the repository root (similar to pytest, mypy, ruff, etc).

See: https://pylint.pycqa.org/en/v2.10.2/faq.html#where-is-the-persistent-data-stored-to-compare-between-successive-runs