### PR TITLE
Remove invalid coverage option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,6 @@ omit = [
 [tool.coverage.xml]
 output = "build/test-coverage.xml"
 
-source_pkgs = ["python_training_project"]
-
 [tool.ruff]
 include = [
     "pyproject.toml",


### PR DESCRIPTION
The `source_pkgs` is not supported within `[tool.coverage.xml]` and not required within `[tool.coverage.run]`. Therefore, we just remove this option.