### PR TITLE
Migrate license in project.classifiers to project.license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python_training_project"
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "Andreas Nussberger", email = "andreas@devminds.ch"},
     {name = "Thomas Keller", email = "thomas@devminds.ch"},
@@ -15,11 +17,6 @@ authors = [
 description = "Python Training Project by devminds GmbH"
 readme = "README.md"
 requires-python = ">=3.10"
-classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-]
 dependencies = [
     "click",
     "flake8-gl-codeclimate>=0.2.1",


### PR DESCRIPTION
Fixes package build warnings introduced by PEP 639:

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license